### PR TITLE
Added ARM64 support for GitHub Release

### DIFF
--- a/.github/workflows/publish_gh.yml
+++ b/.github/workflows/publish_gh.yml
@@ -40,6 +40,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin # This is the one for your M1 Mac
@@ -56,8 +58,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install aarch64 linker
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build binary
         working-directory: ./tbdflow-rs
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
         run: cargo build --verbose --release --target ${{ matrix.target }}
 
       - name: Package binary for release

--- a/tbdflow-rs/Cargo.toml
+++ b/tbdflow-rs/Cargo.toml
@@ -23,6 +23,8 @@ serde = { version = "1.0.219", features = ["derive"] }
 dialoguer = "0.11.0"
 self_update = "0.42.0"
 regex = "1.11.1"
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+openssl-sys = { version = "0.9.109", features = ["vendored"] }
 
 [dev-dependencies]
 serial_test = "3.2.0"


### PR DESCRIPTION
I'm Linux ARM64 user. I'm aware that it is not a super popular platform 😅, but still it may be useful for folks like me to be able to start using `tbdflow` without building it locally.

Supporting multi-arch builds for Linux is not super-trivial in GitHub Actions environment, mainly due to issues with OpenSSL package. IMHO the best option for current GitHub Action to support both ARM64 and x86 is to make `openssl-sys` dependency vendored for ARM64 build. In practice it means that for Linux ARM64 build cargo will download, compile and use openssl instead of relying on system package. It will be slightly slower to built, but independent from building machine OS. All other platforms will still rely on system package as before.

I'm not 100% happy with the fact that Linux ARM64 build has openssl version specified explicitly, while other rely on transitive dependencies versions. But again, considering how tricky multi-arch Linux SSL setup can be for GitHub Actions, I think it is acceptable 😅 .