### PR TITLE
test: fix test failing due to missing upstream

### DIFF
--- a/tbdflow-rs/tests/util.rs
+++ b/tbdflow-rs/tests/util.rs
@@ -15,6 +15,7 @@ pub fn setup_temp_git_repo() -> (TempDir, TempDir, std::path::PathBuf) {
     Command::new("git").arg("init").current_dir(&repo_path).output().unwrap();
     Command::new("git").args(&["config", "user.email", "test@example.com"]).current_dir(&repo_path).output().unwrap();
     Command::new("git").args(&["config", "user.name", "Test"]).current_dir(&repo_path).output().unwrap();
+    Command::new("git").args(&["config", "push.autoSetupRemote", "true"]).current_dir(&repo_path).output().unwrap();
     let file_path = repo_path.join("README.md");
     write(&file_path, "test").unwrap();
     Command::new("git").args(&["add", "."]).current_dir(&repo_path).output().unwrap();


### PR DESCRIPTION
One the tests failures that I can reproduce on my machine is the following when running `cargo test test_commit_command`:

```
Error: Git command failed: fatal: The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin master

To have this happen automatically for branches without a tracking
upstream, see \'push.autoSetupRemote\' in \'git help config\'.
```

My environment doesn't have `push.autoSetupRemote` set by default, while current version of the test seems to be assuming so. 

My change sets explicit test git project setting of `push.autoSetupRemote` to `true`. I think this is reasonable thing to do, as it makes code less dependent on global git settings when running tests.