### PR TITLE
test: improve git output assertion

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,6 @@
 use assert_cmd::Command;
 use predicates::str::contains;
+use predicates::str::is_match;
 use serial_test::serial;
 use chrono::{Duration, Utc};
 
@@ -117,7 +118,17 @@ fn test_commit_command() {
         .arg("--tag").arg("button-v1");
     cmd.assert()
         .success()
-        .stdout(contains("Successfully committed and pushed changes to main."));
+        .stdout(
+        /*
+        Depending on Git version used, output may vary slightly. For example:
+        - Successfully committed and pushed changes to BRANCH_NAME.
+        - Successfully pushed changes to 'BRANCH_NAME'.
+
+        Also default branch name can be 'main' or 'master', depending on the Git version
+        and distribution. Below is a regex that matches all those cases.
+        */
+        is_match(r"Successfully (?:committed and )?pushed changes to '?(?:main|master)'?\.").unwrap()
+	);
 
     // Check that the tag exists
     let output = std::process::Command::new("git")


### PR DESCRIPTION
Running `cargo test test_commit_command` on my local machine (WSL2 + Ubuntu) fails because my combination of Linux distribution, Git distribution and default Git global settings are generating slightly different output which causes test assertion to fail even though test performed expected action (committed changes in this case).

I replaced fixed-string comparison with regex-based one which is more flexible to reflect such subtle distro-related differences.