### PR TITLE
(ci) Add "cargo fmt" check to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Set git default branch to main
         run: git config --global init.defaultBranch main
 
+      - name: Check cargo formatting
+        run: cargo fmt -- --check
+
       - name: Build
         run: cargo build
 


### PR DESCRIPTION
This PR adds CI check to verify that pushed code is formatted using `cargo fmt`. Check should be done before more time consuming tasks like building, so it can fail fast.

Right now this pull request is failing because current version of project is not formatted, but merging #5 will fix it 😉