### PR TITLE
ci: remove obsolete init branch setup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set git default branch to main
-        run: git config --global init.defaultBranch main
-
       - name: Check cargo formatting
         run: cargo fmt -- --check
 


### PR DESCRIPTION
Now with #9 merged, we can remove obsolete init branch setup from CI. 😉